### PR TITLE
NO-JIRA: Allow addiing arm64 nodes to baremetal platforms

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -979,16 +979,12 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
 			supported = true
 		}
-	case hyperv1.NonePlatform:
-		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
-			supported = true
-		}
 	case hyperv1.AzurePlatform, hyperv1.KubevirtPlatform:
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
 			supported = true
 		}
 	case hyperv1.AgentPlatform:
-		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitecturePPC64LE {
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitecturePPC64LE || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
 			supported = true
 		}
 	case hyperv1.PowerVSPlatform:

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -991,6 +991,10 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 		if nodePool.Spec.Arch == hyperv1.ArchitecturePPC64LE {
 			supported = true
 		}
+	case hyperv1.NonePlatform:
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
+			supported = true
+		}
 	}
 
 	return supported

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -979,6 +979,10 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
 			supported = true
 		}
+	case hyperv1.NonePlatform:
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureARM64 {
+			supported = true
+		}
 	case hyperv1.AzurePlatform, hyperv1.KubevirtPlatform:
 		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
 			supported = true

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3134,6 +3134,30 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "supported platform with multiple arch baremetal - arm64",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.NonePlatform,
+					},
+					Arch: hyperv1.ArchitectureARM64,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "supported platform with multiple arch baremetal - amd64",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.NonePlatform,
+					},
+					Arch: hyperv1.ArchitectureAMD64,
+				},
+			},
+			expect: true,
+		},
+		{
 			name: "unsupported arch and platform used",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3110,6 +3110,18 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "supported platform with multiple arch baremetal - arm64",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.NonePlatform,
+					},
+					Arch: hyperv1.ArchitectureARM64,
+				},
+			},
+			expect: true,
+		},
+		{
 			name: "supported platform with multiple arch - amd64",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
@@ -3139,6 +3151,18 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 				Spec: hyperv1.NodePoolSpec{
 					Platform: hyperv1.NodePoolPlatform{
 						Type: hyperv1.AWSPlatform,
+					},
+					Arch: hyperv1.ArchitecturePPC64LE,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "unsupported arch and platform used",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.NonePlatform,
 					},
 					Arch: hyperv1.ArchitecturePPC64LE,
 				},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3098,6 +3098,18 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "supported platform with multiple arch baremetal - amd64",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.NonePlatform,
+					},
+					Arch: hyperv1.ArchitectureAMD64,
+				},
+			},
+			expect: true,
+		},
+		{
 			name: "supported platform with multiple arch - amd64",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3098,23 +3098,11 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 			expect: true,
 		},
 		{
-			name: "supported platform with multiple arch baremetal - amd64",
-			nodePool: &hyperv1.NodePool{
-				Spec: hyperv1.NodePoolSpec{
-					Platform: hyperv1.NodePoolPlatform{
-						Type: hyperv1.NonePlatform,
-					},
-					Arch: hyperv1.ArchitectureAMD64,
-				},
-			},
-			expect: true,
-		},
-		{
 			name: "supported platform with multiple arch baremetal - arm64",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{
 					Platform: hyperv1.NodePoolPlatform{
-						Type: hyperv1.NonePlatform,
+						Type: hyperv1.AgentPlatform,
 					},
 					Arch: hyperv1.ArchitectureARM64,
 				},
@@ -3151,18 +3139,6 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 				Spec: hyperv1.NodePoolSpec{
 					Platform: hyperv1.NodePoolPlatform{
 						Type: hyperv1.AWSPlatform,
-					},
-					Arch: hyperv1.ArchitecturePPC64LE,
-				},
-			},
-			expect: false,
-		},
-		{
-			name: "unsupported arch and platform used",
-			nodePool: &hyperv1.NodePool{
-				Spec: hyperv1.NodePoolSpec{
-					Platform: hyperv1.NodePoolPlatform{
-						Type: hyperv1.NonePlatform,
 					},
 					Arch: hyperv1.ArchitecturePPC64LE,
 				},


### PR DESCRIPTION
Add a check to grant modification of a nodepool when the platform is baremetal. Currently multi-arch setup is allowed only for AWS, expanding the same to baremetal platforms.

